### PR TITLE
Implement MarketDataBot service

### DIFF
--- a/.well-known/agent.json
+++ b/.well-known/agent.json
@@ -1,0 +1,19 @@
+{
+  "name": "MarketDataBot",
+  "description": "Provides real-time stock prices using Yahoo Finance.",
+  "version": "1.0",
+  "endpoint": "http://localhost:8000/price",
+  "tasks": [
+    {
+      "name": "get_price",
+      "description": "Returns the latest price for a stock symbol.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "symbol": { "type": "string" }
+        },
+        "required": ["symbol"]
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # marketDataAgent
+
+A small FastAPI service that returns real-time stock prices from Yahoo Finance.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+```bash
+uvicorn app:app --reload --port 8000
+```
+
+## Endpoints
+
+- `POST /price` – request body `{ "symbol": "AAPL" }` returns latest price
+- `GET /.well-known/agent.json` – returns the agent card used for discovery
+
+## Example
+
+```bash
+curl -X POST "http://localhost:8000/price" -H "Content-Type: application/json" -d '{"symbol": "AAPL"}'
+curl http://localhost:8000/.well-known/agent.json
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,40 @@
+import json
+import logging
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import yfinance as yf
+
+
+logger = logging.getLogger("market_data_bot")
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI()
+
+
+class PriceRequest(BaseModel):
+    symbol: str
+
+
+@app.post("/price")
+async def get_price(req: PriceRequest):
+    symbol = req.symbol
+    ticker = yf.Ticker(symbol)
+    price = ticker.info.get("regularMarketPrice")
+    logger.info("MarketDataBot: %s price is %s", symbol, price)
+    if price is None:
+        raise HTTPException(status_code=404, detail="Symbol not found")
+    return {"symbol": symbol, "price": price}
+
+
+@app.get("/.well-known/agent.json")
+async def agent_card():
+    agent_path = Path(__file__).parent / ".well-known" / "agent.json"
+    try:
+        with agent_path.open() as f:
+            return json.load(f)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="agent.json not found")
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=500, detail="Invalid agent.json")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+yfinance


### PR DESCRIPTION
## Summary
- add FastAPI service with `/price` endpoint returning Yahoo Finance data
- expose agent card at `/.well-known/agent.json`
- include requirements and usage docs

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement fastapi)*
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e83ec0704832192adc9fb21dab637