### PR TITLE
Improve price endpoint and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ uvicorn app:app --reload --port 8000
 curl -X POST "http://localhost:8000/price" -H "Content-Type: application/json" -d '{"symbol": "AAPL"}'
 curl http://localhost:8000/.well-known/agent.json
 ```
+
+## Testing
+
+```bash
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -1,9 +1,12 @@
+import asyncio
 import json
 import logging
+from functools import lru_cache
 from pathlib import Path
+from typing import Optional
 
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 import yfinance as yf
 
 
@@ -14,27 +17,59 @@ app = FastAPI()
 
 
 class PriceRequest(BaseModel):
+    """Request model for the /price endpoint."""
+
+    symbol: str = Field(
+        ..., pattern=r"^[A-Z]{1,5}$", description="Ticker symbol, 1-5 uppercase letters"
+    )
+
+
+class PriceResponse(BaseModel):
+    """Response model for the /price endpoint."""
+
     symbol: str
+    price: float
 
 
-@app.post("/price")
-async def get_price(req: PriceRequest):
-    symbol = req.symbol
+@lru_cache(maxsize=256)
+def _fetch_price(symbol: str) -> Optional[float]:
+    """Fetch the latest price for *symbol* using yfinance."""
+
     ticker = yf.Ticker(symbol)
-    price = ticker.info.get("regularMarketPrice")
+    try:
+        price = ticker.fast_info.get("lastPrice")
+        if price is None:
+            price = ticker.info.get("regularMarketPrice")
+    except Exception:
+        logger.exception("Failed to fetch price for %s", symbol)
+        return None
+    return price
+
+
+@app.post("/price", response_model=PriceResponse)
+async def get_price(req: PriceRequest) -> PriceResponse:
+    """Return the latest market price for the requested symbol."""
+
+    symbol = req.symbol
+    loop = asyncio.get_running_loop()
+    price = await loop.run_in_executor(None, _fetch_price, symbol)
     logger.info("MarketDataBot: %s price is %s", symbol, price)
     if price is None:
         raise HTTPException(status_code=404, detail="Symbol not found")
-    return {"symbol": symbol, "price": price}
+    return PriceResponse(symbol=symbol, price=price)
 
 
 @app.get("/.well-known/agent.json")
-async def agent_card():
+async def agent_card() -> dict:
+    """Serve the agent metadata for discovery."""
+
     agent_path = Path(__file__).parent / ".well-known" / "agent.json"
     try:
         with agent_path.open() as f:
             return json.load(f)
     except FileNotFoundError:
+        logger.exception("agent.json not found at %s", agent_path)
         raise HTTPException(status_code=404, detail="agent.json not found")
     except json.JSONDecodeError:
+        logger.exception("agent.json at %s is invalid JSON", agent_path)
         raise HTTPException(status_code=500, detail="Invalid agent.json")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 yfinance
+pytest

--- a/tests/test_price.py
+++ b/tests/test_price.py
@@ -1,0 +1,16 @@
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import PriceRequest, _fetch_price
+
+
+def test_price_request_validation():
+    with pytest.raises(ValueError):
+        PriceRequest(symbol="invalid$")
+
+
+def test_fetch_price_invalid_symbol():
+    assert _fetch_price("ZZZZ") is None


### PR DESCRIPTION
## Summary
- add validation, response model, and caching to `/price`
- improve agent.json error logging
- document test run and add basic tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fb5a8e0fc8321b83e6811bec31a73